### PR TITLE
Fix bug in is_classification

### DIFF
--- a/tabpfn/scripts/tabular_metrics.py
+++ b/tabpfn/scripts/tabular_metrics.py
@@ -111,7 +111,7 @@ def neg_r2(target, pred):
     return -r2_score(pred.float(), target.float())
 
 def is_classification(metric_used):
-    if metric_used == auc_metric or metric_used == cross_entropy:
+     if metric_used.__name__ in ["auc_metric", "cross_entropy"]:
         return True
     return False
 

--- a/tabpfn/scripts/tabular_metrics.py
+++ b/tabpfn/scripts/tabular_metrics.py
@@ -111,7 +111,7 @@ def neg_r2(target, pred):
     return -r2_score(pred.float(), target.float())
 
 def is_classification(metric_used):
-     if metric_used.__name__ in ["auc_metric", "cross_entropy"]:
+    if metric_used.__name__ in ["auc_metric", "cross_entropy"]:
         return True
     return False
 


### PR DESCRIPTION
Because of an issue in is_classification, auc_metric is not recognized as classification metric and invalid splits are generated on the validation set.

There is another implementation of ``is_classification`` that is correct, but this one is used.