### PR TITLE
Update transformer_prediction_interface.py

### DIFF
--- a/tabpfn/scripts/transformer_prediction_interface.py
+++ b/tabpfn/scripts/transformer_prediction_interface.py
@@ -150,7 +150,7 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin):
         if model_key in self.models_in_memory:
             model, c, results_file = self.models_in_memory[model_key]
         else:
-            model, c, results_file = load_model_workflow(i, -1, add_name=model_string, base_path=base_path, device=device,
+            model, c, results_file = load_model_workflow(i, 42, add_name=model_string, base_path=base_path, device=device,
                                                          eval_addition='', only_inference=only_inference)
             self.models_in_memory[model_key] = (model, c, results_file)
             if len(self.models_in_memory) == 2:


### PR DESCRIPTION
Hello, and first of all, thank you so much for your excellent work!
I've observed that while we have 'models_diff/prior_diff_real_checkpoint_n_0_epoch_42.cpkt' available locally, when executing TabPFN = TabPFNClassifier(device='cpu', N_ensemble_configurations=32), the code seems to first look for a non-existent file named 'prior_diff_real_checkpoint_n_0_epoch_100.cpkt', which then triggers a download. Unfortunately, this download does not succeed, perhaps due to my location in China.

In light of this, I have taken the liberty of adjusting the 'e' parameter in the load_model_workflow() function to 42, in hopes of bypassing the need for downloading.