### PR TITLE
Update transformer_prediction_interface.py

### DIFF
--- a/tabpfn/scripts/transformer_prediction_interface.py
+++ b/tabpfn/scripts/transformer_prediction_interface.py
@@ -76,7 +76,7 @@ def load_model_workflow(i, e, add_name, base_path, device='cpu', eval_addition='
 
     model_file = None
     if e == -1:
-        for e_ in range(100, -1, -1):
+        for e_ in [42] + list(range(100, -1, -1)):
             model_file_, model_path_, results_file_ = check_file(e_)
             if model_file_ is not None:
                 e = e_


### PR DESCRIPTION
Problems of checking model files?

From line 79 in https://github.com/automl/TabPFN/blob/d76f4ac7da5254322143edb6650f88dd5e8c186c/tabpfn/scripts/transformer_prediction_interface.py, we check whether the model file from epoch 100 to 0 exists:

```python
    for e_ in range(100, -1, -1):
        model_file_, model_path_, results_file_ = check_file(e_)
```
We expect it will get a model file because there exists a `prior_diff_real_checkpoint_n_0_epoch_42.cpkt` by default.

But in line 67, we will download the model when `e=100`:

```python
if not Path(model_path).is_file():  # or Path(results_file).is_file():
```

So, I fixed this problem by check `e=42` firstly.