### PR TITLE
Update model_builder.py and transformer_prediction_interface.py for mixed precision training and inference

### DIFF
--- a/tabpfn/scripts/model_builder.py
+++ b/tabpfn/scripts/model_builder.py
@@ -308,6 +308,7 @@ def get_model(config, device, should_train=True, verbose=False, state_dict=None,
                   , recompute_attn=config['recompute_attn']
                   , epoch_callback=epoch_callback
                   , bptt_extra_samples = config['bptt_extra_samples']
+                  , train_mixed_precision = config['train_mixed_precision']
                   , extra_prior_kwargs_dict={
             'num_features': config['num_features']
             , 'hyperparameters': prior_hyperparameters

--- a/tabpfn/scripts/transformer_prediction_interface.py
+++ b/tabpfn/scripts/transformer_prediction_interface.py
@@ -546,7 +546,7 @@ def transformer_predict(model, eval_xs, eval_ys, eval_position,
 
     output = output / len(ensemble_configurations)
     if average_logits and not return_logits:
-        if average_logits and not return_logits:
+        if fp16_inference:
             output = output.float()
         output = torch.nn.functional.softmax(output, dim=-1)
 

--- a/tabpfn/scripts/transformer_prediction_interface.py
+++ b/tabpfn/scripts/transformer_prediction_interface.py
@@ -546,6 +546,8 @@ def transformer_predict(model, eval_xs, eval_ys, eval_position,
 
     output = output / len(ensemble_configurations)
     if average_logits and not return_logits:
+        if average_logits and not return_logits:
+            output = output.float()
         output = torch.nn.functional.softmax(output, dim=-1)
 
     output = torch.transpose(output, 0, 1)


### PR DESCRIPTION
Variable `train_mixed_precision` seems to have not been passed into the train function, which means that mixed precision training cannot be performed